### PR TITLE
FIX - 테스트코드 실행 오류 수정

### DIFF
--- a/be_Gomunity/urls.py
+++ b/be_Gomunity/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('user/', include('user.urls')),
-    path('webmaster/', include(('webmaster.urls','webmaster'), namespace='webmaster')),
+    path('webmaster/', include('webmaster.urls')),
+    # path('webmaster/', include(('webmaster.urls','webmaster'), namespace='webmaster')),
 ]

--- a/webmaster/tests.py
+++ b/webmaster/tests.py
@@ -6,26 +6,34 @@ from django.urls import reverse
 
 
 class NoticeTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_data = {'username' : 'heejeong', 'password': '1234'}
+        cls.notice_data = {'title' : '안녕' , 'content' : '반갑습니다'}
+        cls.user = UserModel.objects.create_user('heejeong', '1234')
+
     def setUp(self):
-        self.user = UserModel.objects.create_user('admin', '123')
-        title = "거뮤니티 ver.1.0 개발노트"
-        content = "회원가입, 로그인, 공지사항, 질문 답글 게시판이 추가되었습니다"
+        self.access_token = self.client.post(reverse('token_obtain_pair'), self.user_data).data['access']
 
-        self.data = {
-            "user" : self.user.id,
-            "title" : title,
-            "content": content
-        }
-
-        self.notice = NoticeModel.objects.create(**self.data)
-        self.user = NoticeModel.objects.all()
-
+    # 공지사항 목록 조회 API 
     def test_list_notice(self):
-        response = self.client.get(reverse('webmaster:list_notice'), self.data)
-        print(f'이건 겟 -> {response.data}')
+        response = self.client.get(reverse('list_notice'))
         self.assertEqual(response.status_code,200)
+        
+    # 공지사항 작성하기 API
+    def test_post_notice(self):
+        response = self.client.post(
+            path = reverse("notice"), 
+            data = self.notice_data,
+            HTTP_AUTHORIZATION = f"Bearer {self.access_token}"
+            )
+        self.assertEqual(response.status_code, 200)
 
-    def test_notice(self):
-        response = self.client.post(reverse('webmaster:notice'), self.data)
-        print(f'이건 포스트 -> {response.data}')
-        self.assertEqual(response.status_code,200)
+# 아티클 생성한거 테스트 하는 코드는 이런데 공지글 작성 테스트는 다른가여?
+        # def test_create_article(self):
+        # response = self.client.post(
+        #     path = reverse("article_view"),
+        #     data = self.article_data,
+        #     HTTP_AUTHORIZATION = f"Bearer {self.access_token}"
+        # )
+        # self.assertEqual(response.data['message'], "글 작성 완료!!")

--- a/webmaster/views.py
+++ b/webmaster/views.py
@@ -8,15 +8,15 @@ from rest_framework import status
 # Create your views here.
 class NoticeListView(APIView):
     def get(self, request):
-        notices = NoticeModel.objects.get(id=1)
-        return Response(NoticeListSerializer(notices).data, status=status.HTTP_200_OK)
+        notices = NoticeModel.objects.all()
+        return Response(NoticeListSerializer(notices, many=True).data, status=status.HTTP_200_OK)
 
 class NoticeView(APIView):
     def post(self, request):
-        request.data['user'] = request.user
+        # request.data['user'] = request.user.id
         notice_serializer = NoticeSerializer(data=request.data)
         if notice_serializer.is_valid():
-            notice_serializer.save()
+            notice_serializer.save(user=self.request.user)
             return Response({"message" : "공지사항 작성에 성공했다북!"}, status=status.HTTP_200_OK)
         else:
             print(notice_serializer.errors)

--- a/webmaster/views.py
+++ b/webmaster/views.py
@@ -13,11 +13,11 @@ class NoticeListView(APIView):
 
 class NoticeView(APIView):
     def post(self, request):
+        request.data['user'] = request.user
         notice_serializer = NoticeSerializer(data=request.data)
-        print(notice_serializer)
         if notice_serializer.is_valid():
             notice_serializer.save()
-            return Response({"message": "공지사항 작성에 성공했다북"}, status=status.HTTP_200_OK)
+            return Response({"message" : "공지사항 작성에 성공했다북!"}, status=status.HTTP_200_OK)
         else:
             print(notice_serializer.errors)
-            return Response({"message": "공지사항 작성에 실패했다북"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"message" : "공지사항 작성에 실패했다북..."}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
테스트코드에서 Immutable QueryDict 형태인 request.data를 수정할 수 없게 되는 상황이 발생했습니다
- NoticeSerializer를 생성하는 과정 중, validation에서 억지로 request.data를 수정하게 만드는 request.user는 검증을 거치지 않아도 되는 자료이므로 제외하고, save()메서드 안에 넣어주는 것으로 모든 데이터를 받아 생성하게 만들도록 수정하였습니다.
Pull Request 확인하시고 코멘트 부탁드립니다